### PR TITLE
Fix maven build

### DIFF
--- a/sonarqube-plugin-greenit/.gitignore
+++ b/sonarqube-plugin-greenit/.gitignore
@@ -3,3 +3,4 @@ yarn.lock
 target/
 node/
 sonar-example-plugin.iml
+.idea

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/pom.xml
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/pom.xml
@@ -79,6 +79,31 @@
                     <!-- <requirePlugins>java:${sonarjava.version}</requirePlugins> -->
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                        <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                        <artifactItems>
+                            <artifactItem>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>${project.artifactId}</artifactId>
+                            <version>${project.version}</version>
+                            <type>jar</type>
+                            <overWrite>true</overWrite>
+                            </artifactItem>
+                        </artifactItems>
+                        <outputDirectory>../lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sonarqube-plugin-greenit/native-analyzer/php-plugin/pom.xml
+++ b/sonarqube-plugin-greenit/native-analyzer/php-plugin/pom.xml
@@ -50,6 +50,31 @@
                     <basePlugin>php</basePlugin>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                        <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                        <artifactItems>
+                            <artifactItem>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>${project.artifactId}</artifactId>
+                            <version>${project.version}</version>
+                            <type>jar</type>
+                            <overWrite>true</overWrite>
+                            </artifactItem>
+                        </artifactItems>
+                        <outputDirectory>../lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sonarqube-plugin-greenit/native-analyzer/pom.xml
+++ b/sonarqube-plugin-greenit/native-analyzer/pom.xml
@@ -152,49 +152,5 @@
 
 		</dependencies>
 	</dependencyManagement>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>copy-libs</id>
-						<phase>package</phase>
-						<goals>
-							<goal>copy</goal>
-						</goals>
-						<configuration>
-							<artifactItems>
-								<artifactItem>
-									<groupId>fr.cnumr</groupId>
-									<artifactId>java-plugin</artifactId>
-									<version>${project.version}</version>
-									<type>jar</type>
-									<overWrite>true</overWrite>
-								</artifactItem>
-								<artifactItem>
-									<groupId>fr.cnumr</groupId>
-									<artifactId>php-plugin</artifactId>
-									<version>${project.version}</version>
-									<type>jar</type>
-									<overWrite>true</overWrite>
-								</artifactItem>
-								<artifactItem>
-									<groupId>fr.cnumr</groupId>
-									<artifactId>python-plugin</artifactId>
-									<version>${project.version}</version>
-									<type>jar</type>
-									<overWrite>true</overWrite>
-								</artifactItem>
-							</artifactItems>
-							<overWriteReleases>false</overWriteReleases>
-							<overWriteSnapshots>true</overWriteSnapshots>
-							<outputDirectory>${project.build.directory}/lib</outputDirectory>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+	
 </project>

--- a/sonarqube-plugin-greenit/native-analyzer/python-plugin/pom.xml
+++ b/sonarqube-plugin-greenit/native-analyzer/python-plugin/pom.xml
@@ -54,6 +54,31 @@
                     <requirePlugins>python:${sonar.python.version}</requirePlugins>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                        <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                        <artifactItems>
+                            <artifactItem>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>${project.artifactId}</artifactId>
+                            <version>${project.version}</version>
+                            <type>jar</type>
+                            <overWrite>true</overWrite>
+                            </artifactItem>
+                        </artifactItems>
+                        <outputDirectory>../lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Fix maven copy task in main module that was applied before each plugin jar. Performed it in each sub-module after jar generation. jars are copied into 'sonarqube-plugin-greenit/lib'. Note that the copies are not used by the docker instance since it directly uses the one in the 'targets' subfolders. I do not really now why this copy must be done.