### PR TITLE
android-plugin: remove deprecated call to a sonarjava method in rules to be compatible with last sonarqube

### DIFF
--- a/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/bottleneck/InternetInTheLoopRule.java
+++ b/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/bottleneck/InternetInTheLoopRule.java
@@ -28,10 +28,6 @@ public class InternetInTheLoopRule extends IssuableSubscriptionVisitor {
 
     @Override
     public void visitNode(Tree tree) {
-        //check usage
-        if (!hasSemantic()) {
-            return;
-        }
         MethodInvocationTree mit = (MethodInvocationTree) tree;
         if (METHOD_MATCHER.matches(mit)) {
             reportIssueIfInLoop(mit, mit);

--- a/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/helpers/ConstructorBeforeMethodCheck.java
+++ b/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/helpers/ConstructorBeforeMethodCheck.java
@@ -81,10 +81,6 @@ public abstract class ConstructorBeforeMethodCheck extends IssuableSubscriptionV
 
     @Override
     public void visitNode(Tree tree) {
-        //check usage
-        if (!hasSemantic()) {
-            return;
-        }
         if (tree.is(Tree.Kind.NEW_CLASS)) {
             NewClassTree newClasstree = (NewClassTree) tree;
             if (newClasstree.symbolType().fullyQualifiedName().equals(ownerType)) {

--- a/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/helpers/OpeningClosingMethodCheck.java
+++ b/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/helpers/OpeningClosingMethodCheck.java
@@ -83,10 +83,6 @@ public abstract class OpeningClosingMethodCheck extends IssuableSubscriptionVisi
 
     @Override
     public void visitNode(Tree tree) {
-        //check usage
-        if (!hasSemantic()) {
-            return;
-        }
         MethodInvocationTree mit = (MethodInvocationTree) tree;
         if (matcherOpeningMethod.matches(mit)) {
             openingMethodTreeList.add(mit);

--- a/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/helpers/SpecificMethodCheck.java
+++ b/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/helpers/SpecificMethodCheck.java
@@ -55,10 +55,6 @@ public abstract class SpecificMethodCheck extends IssuableSubscriptionVisitor {
 
     @Override
     public void visitNode(Tree tree) {
-        //check usage
-        if (!hasSemantic()) {
-            return;
-        }
         if (tree.is(Tree.Kind.METHOD_INVOCATION)) {
             MethodInvocationTree mit = (MethodInvocationTree) tree;
             if (methodMatcher.matches(mit)) {

--- a/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/helpers/constant/ArgumentValueOnMethodCheck.java
+++ b/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/helpers/constant/ArgumentValueOnMethodCheck.java
@@ -81,10 +81,6 @@ public abstract class ArgumentValueOnMethodCheck extends IssuableSubscriptionVis
 
     @Override
     public void visitNode(Tree tree) {
-        //check usage
-        if (!hasSemantic()) {
-            return;
-        }
         MethodInvocationTree mit = (MethodInvocationTree) tree;
         for (MethodSpecs currentMethodSpecs : methodsSpecs) {
             MethodMatchers matcher = MethodMatchers.create().ofTypes(currentMethodSpecs.getMethodOwner()).names(currentMethodSpecs.getMethodName()).withAnyParameters().build();

--- a/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/idleness/DurableWakeLockRule.java
+++ b/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/idleness/DurableWakeLockRule.java
@@ -46,10 +46,6 @@ public class DurableWakeLockRule extends IssuableSubscriptionVisitor {
 
     @Override
     public void visitNode(Tree tree) {
-        //check usage
-        if (!hasSemantic()) {
-            return;
-        }
         MethodInvocationTree mit = (MethodInvocationTree) tree;
         if (matcher.matches(mit)) {
             reportIssue(mit, ERROR_MESSAGE);

--- a/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/idleness/KeepVoiceAwakeRule.java
+++ b/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/idleness/KeepVoiceAwakeRule.java
@@ -84,10 +84,6 @@ public class KeepVoiceAwakeRule extends IssuableSubscriptionVisitor {
 
     @Override
     public void visitNode(Tree tree) {
-        //check usage
-        if (!hasSemantic()) {
-            return;
-        }
         if (tree.is(Tree.Kind.NEW_CLASS)) {
             NewClassTree newClasstree = (NewClassTree) tree;
             if (newClasstree.symbolType().fullyQualifiedName().equals(ownerType)) {

--- a/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/sobriety/ThriftyGeolocationMinDistanceRule.java
+++ b/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/sobriety/ThriftyGeolocationMinDistanceRule.java
@@ -54,9 +54,6 @@ public class ThriftyGeolocationMinDistanceRule extends IssuableSubscriptionVisit
 
     @Override
     public void visitNode(Tree tree) {
-        if (!hasSemantic()) {
-            return;
-        }
         if (tree.is(Tree.Kind.METHOD_INVOCATION)) {
             MethodInvocationTree mit = (MethodInvocationTree) tree;
             if (methodMatcher.matches(mit)) {

--- a/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/sobriety/ThriftyGeolocationMinTimeRule.java
+++ b/sonarqube-plugin-greenit/native-analyzer/android-plugin/src/main/java/io/ecocode/java/checks/sobriety/ThriftyGeolocationMinTimeRule.java
@@ -54,9 +54,6 @@ public class ThriftyGeolocationMinTimeRule extends IssuableSubscriptionVisitor {
 
     @Override
     public void visitNode(Tree tree) {
-        if (!hasSemantic()) {
-            return;
-        }
         if (tree.is(Tree.Kind.METHOD_INVOCATION)) {
             MethodInvocationTree mit = (MethodInvocationTree) tree;
             if (methodMatcher.matches(mit)) {


### PR DESCRIPTION
Be compatible with new sonar (9.3) while keeping compatibility with old (8.6)