### PR TITLE
Maven configuration : coherence artifactID et ajouts de metainfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,20 @@
 README.md.tmp.html
+
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+**/.settings

--- a/src/android-plugin/pom.xml
+++ b/src/android-plugin/pom.xml
@@ -8,7 +8,7 @@
 	<version>1.0-SNAPSHOT</version>
 	<packaging>sonar-plugin</packaging>
 
-	<name>ecoCode Sonarqube plugin</name>
+	<name>ecoCode Android plugin</name>
 	<description>Help the earth, adopt this green plugin for your applications</description>
 	<inceptionYear>2020</inceptionYear>
 

--- a/src/codenarc-converter/pom.xml
+++ b/src/codenarc-converter/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>fr.cnumr</groupId>
-    <artifactId>green-it</artifactId>
+    <artifactId>ecocode</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -15,14 +15,14 @@ services:
       SONAR_ES_BOOTSTRAP_CHECKS_DISABLE: 'true'
     volumes:
       - type: bind
-        source: ./java-plugin/target/java-plugin-1.0.0-SNAPSHOT.jar
-        target: /opt/sonarqube/extensions/plugins/java-plugin-1.0.0-SNAPSHOT.jar
+        source: ./java-plugin/target/ecocode-java-plugin-1.0.0-SNAPSHOT.jar
+        target: /opt/sonarqube/extensions/plugins/ecocode-java-plugin-1.0.0-SNAPSHOT.jar
       - type: bind
-        source: ./php-plugin/target/php-plugin-1.0.0-SNAPSHOT.jar
-        target: /opt/sonarqube/extensions/plugins/php-plugin-1.0.0-SNAPSHOT.jar
+        source: ./php-plugin/target/ecocode-php-plugin-1.0.0-SNAPSHOT.jar
+        target: /opt/sonarqube/extensions/plugins/ecocode-php-plugin-1.0.0-SNAPSHOT.jar
       - type: bind
         source: ./python-plugin/target/python-plugin-1.0.0-SNAPSHOT.jar
-        target: /opt/sonarqube/extensions/plugins/python-plugin-1.0.0-SNAPSHOT.jar
+        target: /opt/sonarqube/extensions/plugins/ecocode-python-plugin-1.0.0-SNAPSHOT.jar
       - type: bind
         source: ./android-plugin/target/ecoCode-rules-1.0-SNAPSHOT.jar
         target: /opt/sonarqube/extensions/plugins/ecoCode-rules-1.0-SNAPSHOT.jar

--- a/src/java-plugin/pom.xml
+++ b/src/java-plugin/pom.xml
@@ -4,15 +4,15 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fr.cnumr</groupId>
-        <artifactId>green-it</artifactId>
+        <artifactId>ecocode</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
 
-    <artifactId>java-plugin</artifactId>
+    <artifactId>ecocode-java-plugin</artifactId>
     <packaging>sonar-plugin</packaging>
 
-    <name>Version Java du plugin</name>
+    <name>ecoCode Java Sonar Plugin</name>
     <description></description>
 
     <dependencies>
@@ -69,8 +69,8 @@
                 <version>${sonar-packaging.version}</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <pluginKey>java-custom</pluginKey>
-                    <pluginName>Ecoconception Web / Les 115 bonnes pratiques</pluginName>
+                    <pluginKey>${project.artifactId}</pluginKey>
+                    <pluginName>${project.name}</pluginName>
                     <pluginClass>fr.cnumr.java.MyJavaRulesPlugin</pluginClass>
                     <sonarLintSupported>true</sonarLintSupported>
                     <sonarQubeMinVersion>${sonarqube.version}</sonarQubeMinVersion>

--- a/src/php-plugin/pom.xml
+++ b/src/php-plugin/pom.xml
@@ -4,15 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fr.cnumr</groupId>
-        <artifactId>green-it</artifactId>
+        <artifactId>ecocode</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>php-plugin</artifactId>
+    <artifactId>ecocode-php-plugin</artifactId>
     <packaging>sonar-plugin</packaging>
-
-
-    <name>Version PHP du plugin</name>
+    <name>ecoCode PHP Sonar Plugin</name>
     <description></description>
 
 
@@ -42,8 +40,8 @@
                 <version>${sonar-packaging.version}</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <pluginKey>php-custom</pluginKey>
-                    <pluginName>PHP Custom Rules</pluginName>
+                    <pluginKey>${project.artifactId}</pluginKey>
+                    <pluginName>${project.name}</pluginName>
                     <pluginClass>fr.cnumr.php.PHPCustomRulesPlugin</pluginClass>
                     <sonarLintSupported>true</sonarLintSupported>
                     <sonarQubeMinVersion>6.7</sonarQubeMinVersion>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>fr.cnumr</groupId>
 
 	<!-- Change this artifactId to your own organization artifactId -->
-	<artifactId>green-it</artifactId>
+	<artifactId>ecocode</artifactId>
 
 	<version>1.0.0-SNAPSHOT</version>
 	<dependencies>
@@ -21,7 +21,7 @@
 
 	<packaging>pom</packaging>
 
-	<name>Plugin Sonarqube des bonnes pratiques d'éco conception</name>
+	<name>ecoCode Sonar Plugins Project</name>
 	<description>Les règles s'appuient sur l'édition 3 du livre "Ecoconception Web / Les 115 bonnes pratiques" =>
 		https://collectif.greenit.fr/ecoconception-web/115-bonnes-pratiques-eco-conception_web.html
 	</description>
@@ -30,10 +30,32 @@
 		<module>java-plugin</module>
 		<module>php-plugin</module>
 		<module>python-plugin</module>
+	<!--	<module>codenarc-converter</module>
 		<module>android-plugin</module>
-		<module>codenarc-converter</module>
+-->
 	</modules>
 
+    <organization>
+        <name>CNumR</name>
+        <url>https://collectif.greenit.fr</url>
+    </organization>
+    <licenses>
+        <license>
+            <name>GNU LGPL 3</name>
+            <url>http://www.gnu.org/licenses/lgpl.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <issueManagement>
+      <system>GitHub</system>
+      <url>https://github.com/cnumr/ecoCode/issues</url>
+    </issueManagement>
+    <scm>
+      <connection>scm:git:https://github.com/cnumr/ecoCode</connection>
+      <developerConnection>scm:git:https://github.com/cnumr/ecoCode</developerConnection>
+      <url>https://github.com/cnumr/ecoCode</url>
+      <tag>HEAD</tag>
+    </scm>
 
 	<properties>
 		<sonarqube.version>8.7.1.42226</sonarqube.version>
@@ -57,7 +79,6 @@
 	</properties>
 
 	<dependencyManagement>
-
 		<dependencies>
 			<!-- MAIN sources dependencies -->
 			<dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -41,8 +41,8 @@
     </organization>
     <licenses>
         <license>
-            <name>GNU LGPL 3</name>
-            <url>http://www.gnu.org/licenses/lgpl.txt</url>
+            <name>GPL v3</name>
+            <url>https://www.gnu.org/licenses/gpl-3.0.en.html</url>
             <distribution>repo</distribution>
         </license>
     </licenses>

--- a/src/python-plugin/pom.xml
+++ b/src/python-plugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fr.cnumr</groupId>
-        <artifactId>green-it</artifactId>
+        <artifactId>ecocode</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>python-plugin</artifactId>
+    <artifactId>ecocode-python-plugin</artifactId>
     <packaging>sonar-plugin</packaging>
 
-    <name>Version Python du plugin</name>
+    <name>ecoCode Python Sonar Plugin</name>
     <description></description>
 
     <dependencies>
@@ -52,6 +52,8 @@
                 <configuration>
                     <pluginClass>fr.cnumr.python.CustomPythonRulesPlugin</pluginClass>
                     <requirePlugins>python:${sonar.python.version}</requirePlugins>
+                    <pluginKey>${project.artifactId}</pluginKey>
+                    <pluginName>${project.name}</pluginName>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Hello,

Quelques améliorations suivantes :
- ajout metainfo dans pom parent : licence, scm, issues, organisation (interpreter dynamiquement pour le packaging sonar)
- renommage artifactID pom parent en ecocode pour refleter le but du depot
- renommage des artifactID et key sonar  des plugins car sont copier coller des projets exemples. (Bug bloquant quand 2 plugins avec meme Key)
- ajout d'un gitignore maven  ( https://github.com/github/gitignore )

Exemple d'affichage dans l'onglet marketplace :
![image](https://user-images.githubusercontent.com/11178020/170585683-e859424e-f069-46e9-b927-ef9b2fe7372d.png)

