### PR TITLE
[Docker] Review compose volume configuration

### DIFF
--- a/src/android-plugin/docker-compose.yml
+++ b/src/android-plugin/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: ecoCode-sonar
     restart: unless-stopped
     volumes:
-      - ./target/ecoCode-rules-1.0-SNAPSHOT.jar:/opt/sonarqube/extensions/plugins/ecoCode-rules-1.0-SNAPSHOT.jar
+      - ./target/ecocode-rules-1.0-SNAPSHOT.jar:/opt/sonarqube/extensions/plugins/ecocode-rules-1.0-SNAPSHOT.jar
     ports:
       - 9000:9000
       - 9092:9092

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -21,11 +21,11 @@ services:
         source: ./php-plugin/target/ecocode-php-plugin-1.0.0-SNAPSHOT.jar
         target: /opt/sonarqube/extensions/plugins/ecocode-php-plugin-1.0.0-SNAPSHOT.jar
       - type: bind
-        source: ./python-plugin/target/python-plugin-1.0.0-SNAPSHOT.jar
+        source: ./python-plugin/target/ecocode-python-plugin-1.0.0-SNAPSHOT.jar
         target: /opt/sonarqube/extensions/plugins/ecocode-python-plugin-1.0.0-SNAPSHOT.jar
       - type: bind
-        source: ./android-plugin/target/ecoCode-rules-1.0-SNAPSHOT.jar
-        target: /opt/sonarqube/extensions/plugins/ecoCode-rules-1.0-SNAPSHOT.jar
+        source: ./android-plugin/target/ecocode-rules-1.0-SNAPSHOT.jar
+        target: /opt/sonarqube/extensions/plugins/ecocode-rules-1.0-SNAPSHOT.jar
       # - "conf:/opt/sonarqube/conf"
       - "extensions:/opt/sonarqube/extensions"
       - "logs:/opt/sonarqube/logs"


### PR DESCRIPTION
- Add missing "ecocode-" prefix for Python plugin (caused build failure)
- Fix case of "ecocode-rules" for Linux systems (case-sensitive), and harmonize naming in the created container (always "ecocode," not "ecoCode")