### PR TITLE
[Docker] Freeze SonarQube's version

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   sonar:
-    image: sonarqube:latest
+    image: sonarqube:9.3-community
     ports:
       - "9000:9000"
     networks:


### PR DESCRIPTION
ecocode-php seems not to work with SonarQube 9.4 (latest). Rather than pulling sonarqube:latest, Docker Compose will now pull sonarqube:9.3-community (the last compatible version).

This is temporary so that the ecoCode challenge can happen with less stress. A more permanent solution will be searched for later.

Note: the documentation of SonarQube plugins does note anything about API changes for SonarQube 9.4 (see https://docs.sonarqube.org/latest/extend/developing-plugin/)