### PR TITLE
Automate CodeNarc build from Maven's initialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+# Markdown
 README.md.tmp.html
 
+# Maven
 target/
 pom.xml.tag
 pom.xml.releaseBackup
@@ -12,9 +14,15 @@ buildNumber.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
 
+# Gradle
+.gradle/
+
 # Eclipse m2e generated files
 # Eclipse Core
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
-**/.settings
+.settings/
+
+# IntelliJ IDEA settings
+.idea/

--- a/src/INSTALL.md
+++ b/src/INSTALL.md
@@ -42,11 +42,7 @@ CodeNarc must be built separately. Please see the following steps:
 Build CodeNarc (Gradle 6.9.2, Java 11), then add this custom-built CodeNarc to Maven dependencies: 
 
 ```sh
-cd codenarc-converter/CodeNarc
-./gradlew build -x test
-cd ..
 mvn initialize
-cd ..
 ```
 
 

--- a/src/codenarc-converter/pom.xml
+++ b/src/codenarc-converter/pom.xml
@@ -125,6 +125,24 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>3.0.0</version>
             <executions>
+              <!-- Trigger Gradle build of CodeNarc -->
+              <execution>
+                <id>generate-codenarc</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>CodeNarc/gradlew</executable>
+                  <arguments>
+                    <argument>-p</argument>
+                    <argument>CodeNarc</argument>
+                    <argument>build</argument>
+                    <argument>-x</argument>
+                    <argument>test</argument>
+                  </arguments>
+                </configuration>
+              </execution>
               <execution>
                 <id>run-codenarc-converter</id>
                 <phase>generate-test-sources</phase>
@@ -147,6 +165,7 @@
             <version>2.5.2</version>
             <executions>
               <execution>
+                <id>deploy-codenarc-to-local-repo</id>
                 <phase>initialize</phase>
                 <goals>
                   <goal>install-file</goal>


### PR DESCRIPTION
`mvn initialize` will now call the gradle build for CodeNarc, thus reducing the number of necessary steps to start working on the project.

The initialize can be run on the root project. The only side-effect is that it will start two jacoco-maven-plugin:prepare-agent. Those don't affect the build, but they could be avoided by changing their execution phase (maybe a phase that would execute it only if tests are run?).

.gradle has been added to the root .gitignore (since the command is not run from the same place and results in a .gradle folder that is not ignored), and comments and a new rule have been added.

This proposal aims to relieve the complexity highlighted in #47 .

A possible enhancement would be to make it so those steps only happen when manually called. A solution for that would be to extract those steps in a `build-codenarc` profile that could only be activated manually (`mvn initialize -Pbuild-codenarc`).