### PR TITLE
fix - Adding 'call' before gradlew to avoid exiting before the end

### DIFF
--- a/src/prepare-codenarc.bat
+++ b/src/prepare-codenarc.bat
@@ -3,7 +3,7 @@ set codenarc_version=2.2.2
 
 REM == Build CodeNarc
 cd codenarc-converter/CodeNarc
-./gradlew build -x test
+call ./gradlew build -x test
 
 REM == Deploy to local repository
 mvn -B install:install-file -Dfile=build/libs/CodeNarc-%codenarc_version%.jar -DgroupId=org.codenarc -DartifactId=CodeNarc -Dversion=%codenarc_version% -Dpackaging=jar


### PR DESCRIPTION
Fixing #149 

The prepare-codenarc.bat script was exiting after the gradlew command not executing the mvn install command, therefore jar were not uploaded in .m2 folder.